### PR TITLE
Support to OOP

### DIFF
--- a/src/lbaselib.c
+++ b/src/lbaselib.c
@@ -488,6 +488,27 @@ static int luaB_collectgarbage (lua_State *L) {
 static int luaB_type (lua_State *L) {
   int t = lua_type(L, 1);
   luaL_argcheck(L, t != LUA_TNONE, 1, "value expected");
+  const int any = 1;
+
+  if (lua_istable(L,1)) {
+    if (lua_getmetatable(L,any)) {
+      const int meta = 2;
+      const int __name = 3;
+
+      lua_pushstring(L,"__name");
+      lua_rawget(L,meta);
+
+      if (lua_type(L, 3) == LUA_TSTRING) {
+        return 1;
+      }
+
+      lua_pushstring(L, "object");
+      return 1;
+    }
+    lua_pushstring(L, "table");
+    return 1;
+  }
+
   lua_pushstring(L, lua_typename(L, t));
   return 1;
 }


### PR DESCRIPTION
This PR implements the support for OOP syntax sugar:

## Object instancing: 

```lua
People = {
  name = "",
  __metatable = {
    __tostring =
      function (self)
        return "My name is "..self.name
      end
    ;
  }
}

isis = new(People)
isis.name = "Isis Manuelly"

print(isis) -- My name is Isis Manuelly
```

## Inheritance:

```lua
Animal = {
  __metatable = {
    __tostring =
      function (self)
        return self.name.. ': ' ..self:speak()
      end
    ;
  }
}

Cat = extends(Animal) {
  speak =
    function (self)
      return "meow"
    end
  ;
}

felix = new(Cat)
felix.name = "Felix, the cat"

print(felix) -- Felix, the cat: meow
```
## Custom types

Now tables with a metatable is treated as `object` instead `table`, and if metatable has a `string` in metatable field `__name`, the value in `__name` is returned:

```lua
type({})                                 -- table
type(setmetatable({},{}))                -- object
type(setmetatable({},{__name='custom'})) -- custom
type(setmetatable({},{__name=123}))      -- object
```

# Resource optmization

Unlike most implementation of OOP for Lua the Iasy implementation is focused on lower overhead and keep the familiarity with tradidional Lua coding, all instances of a "Class" shares the same metatable so metamethod are fully supported by instances, is fast to instance new objects and less RAM is used to provide OOP